### PR TITLE
Renamed PyPolyChord to pypolychord

### DIFF
--- a/docs/demo.ipynb
+++ b/docs/demo.ipynb
@@ -80,7 +80,7 @@
    "source": [
     "## Python likelihoods and priors\n",
     "\n",
-    "Python likelihoods and priors must be defined as functions or callable classes, just as for running PyPolyChord (PolyChord's python wrapper). Otherwise the process is very similar to that with compiled likelihoods."
+    "Python likelihoods and priors must be defined as functions or callable classes, just as for running pypolychord (PolyChord's python wrapper). Otherwise the process is very similar to that with compiled likelihoods."
    ]
   },
   {

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,7 +33,7 @@ Dependencies
 
 
 ``PolyChord`` is available at https://ccpforge.cse.rl.ac.uk/gf/project/polychord/ and has its own installation and licence instructions; see the link for more information.
-Note running ``dyPolyChord`` with compiled C++ or Fortran likelihoods does not require the installation of ``PyPolyChord`` (``PolyChord``'s Python interface).
+Note running ``dyPolyChord`` with compiled C++ or Fortran likelihoods does not require the installation of ``pypolychord`` (``PolyChord``'s Python interface).
 
 
 Tests
@@ -51,5 +51,5 @@ To also get code coverage information (this requires the ``coverage`` package), 
 
     nosetests --with-coverage --cover-erase --cover-package=dyPolyChord
 
-Note that these tests will run without ``PolyChord``. This is to allow all the ``dyPolyChord`` code (including code specifically for Python or compiled likelihoods) to be tested without the need for the user to compile any executables or install ``PyPolyChord``.
-If ``PyPolyChord`` is installed, the tests will also run calculations using Python likelihoods and check their results (otherwise these tests are skipped).
+Note that these tests will run without ``PolyChord``. This is to allow all the ``dyPolyChord`` code (including code specifically for Python or compiled likelihoods) to be tested without the need for the user to compile any executables or install ``pypolychord``.
+If ``pypolychord`` is installed, the tests will also run calculations using Python likelihoods and check their results (otherwise these tests are skipped).

--- a/dyPolyChord/pypolychord_utils.py
+++ b/dyPolyChord/pypolychord_utils.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
-"""Functions for running dyPolyChord using PyPolyChord (PolyChord's
+"""Functions for running dyPolyChord using pypolychord (PolyChord's
 built-in python wrapper) using with python likelihoods and priors.
 """
 # Exception handling needed to allow readthedocs to work without installing
-# PyPolyChord.
+# pypolychord.
 try:
-    import PyPolyChord
-    import PyPolyChord.settings
+    import pypolychord
+    import pypolychord.settings
 except ImportError:
     pass
 
@@ -34,8 +34,8 @@ class RunPyPolyChord(object):
 
     def __call__(self, settings_dict, comm=None):
         """
-        Runs PyPolyChord with specified inputs and writes output files. See the
-        PyPolyChord documentation for more details.
+        Runs pypolychord with specified inputs and writes output files. See the
+        pypolychord documentation for more details.
 
         Parameters
         ----------
@@ -45,15 +45,15 @@ class RunPyPolyChord(object):
             For MPI parallelisation.
         """
         if comm is None:
-            settings = PyPolyChord.settings.PolyChordSettings(
+            settings = pypolychord.settings.PolyChordSettings(
                 self.ndim, self.nderived, **settings_dict)
         else:
             rank = comm.Get_rank()
             if rank == 0:
-                settings = PyPolyChord.settings.PolyChordSettings(
+                settings = pypolychord.settings.PolyChordSettings(
                     self.ndim, self.nderived, **settings_dict)
             else:
                 settings = None
             settings = comm.bcast(settings, root=0)
-        PyPolyChord.run_polychord(self.likelihood, self.ndim, self.nderived,
+        pypolychord.run_polychord(self.likelihood, self.ndim, self.nderived,
                                   settings, prior=self.prior)

--- a/dyPolyChord/python_likelihoods.py
+++ b/dyPolyChord/python_likelihoods.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Loglikelihood functions for use with PyPolyChord (PolyChord's python wrapper).
+Loglikelihood functions for use with pypolychord (PolyChord's python wrapper).
 
 PolyChord v1.14 requires likelihoods to be callables with parameter and return
 signatures:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,7 +3,7 @@
 Test suite for the dyPolyChord package.
 
 Extra tests which check exact results produced using random seeding are
-included, but are skipped unless PyPolyChord is installed. These also require
+included, but are skipped unless pypolychord is installed. These also require
 mpi4py if you have installed PolyChord with MPI.
 """
 import os
@@ -27,17 +27,17 @@ import dyPolyChord.run_dynamic_ns
 import dyPolyChord
 try:
     # pylint: disable=unused-import,ungrouped-imports
-    # Only do pypolychord_utils tests if PyPolyChord is installed
-    import PyPolyChord
+    # Only do pypolychord_utils tests if pypolychord is installed
+    import pypolychord
     import dyPolyChord.pypolychord_utils
     PYPOLYCHORD_AVAIL = True
 except ImportError:
     PYPOLYCHORD_AVAIL = False
     warnings.warn(
-        ('I can\'t import PyPolyChord, so I am skipping the tests which '
-         'need it. PyPolyChord is not needed for compiled C++ and Fortran '
+        ('I can\'t import pypolychord, so I am skipping the tests which '
+         'need it. pypolychord is not needed for compiled C++ and Fortran '
          'likelihoods, so you can ignore this warning. However, you will need '
-         'to install PyPolyChord to run Python likelihoods.'),
+         'to install pypolychord to run Python likelihoods.'),
         UserWarning)
 if PYPOLYCHORD_AVAIL:
     try:
@@ -72,10 +72,10 @@ def setUpModule():
         shutil.rmtree(TEST_CACHE_DIR)
 
 
-@unittest.skipIf(not PYPOLYCHORD_AVAIL, 'PyPolyChord not installed.')
+@unittest.skipIf(not PYPOLYCHORD_AVAIL, 'pypolychord not installed.')
 class TestRunDyPolyChordNumers(unittest.TestCase):
 
-    """Tests for run_dypolychord which use PyPolyChord and check numerical
+    """Tests for run_dypolychord which use pypolychord and check numerical
     outputs by setting random seed."""
 
     def setUp(self):
@@ -532,18 +532,18 @@ class TestPolyChordUtils(unittest.TestCase):
         func({'base_dir': TEST_CACHE_DIR, 'file_root': 'temp'})
 
 
-@unittest.skipIf(not PYPOLYCHORD_AVAIL, 'PyPolyChord not installed.')
+@unittest.skipIf(not PYPOLYCHORD_AVAIL, 'pypolychord not installed.')
 class TestPyPolyChordUtils(unittest.TestCase):
 
     """
     Tests for the pypolychord_utils.py module.
 
-    These are skipped if PyPolyChord is not installed as it is not needed for
+    These are skipped if pypolychord is not installed as it is not needed for
     compiled likelihoods.
     """
 
     def test_python_run_func(self):
-        """Check functions for running PolyChord via the PyPolyChord wrapper
+        """Check functions for running PolyChord via the pypolychord wrapper
         (as opposed to with a compiled likelihood) in the form needed for
         dynamic nested sampling."""
         try:
@@ -687,7 +687,7 @@ class TestPythonPriors(unittest.TestCase):
             hypercube)
 
         def forced_ident_transform(x):
-            """PyPolyChord version of the forced identifiability transform.
+            """pypolychord version of the forced identifiability transform.
             (gives correct value)."""
             n = len(x)
             theta = numpy.zeros(n)


### PR DESCRIPTION
PyPolyChord has been renamed to pypolychord in accordance with normal package naming conventions